### PR TITLE
Add simple calculator web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Calculator
+
+Simple calculator with basic arithmetic operations.
+
+## Usage
+
+Open `index.html` in your browser by double-clicking the file.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Calculator</title>
+  <style>
+    body { font-family: Arial, sans-serif; }
+    #calculator { width: 220px; margin: 50px auto; }
+    #display { width: 100%; height: 40px; font-size: 24px; text-align: right; }
+    button { width: 50px; height: 50px; font-size: 20px; margin: 2px; }
+    .row { display: flex; }
+  </style>
+</head>
+<body>
+  <div id="calculator">
+    <input type="text" id="display" readonly>
+    <div class="row">
+      <button data-value="7">7</button>
+      <button data-value="8">8</button>
+      <button data-value="9">9</button>
+      <button data-value="/">&divide;</button>
+    </div>
+    <div class="row">
+      <button data-value="4">4</button>
+      <button data-value="5">5</button>
+      <button data-value="6">6</button>
+      <button data-value="*">&times;</button>
+    </div>
+    <div class="row">
+      <button data-value="1">1</button>
+      <button data-value="2">2</button>
+      <button data-value="3">3</button>
+      <button data-value="-">-</button>
+    </div>
+    <div class="row">
+      <button data-value="0">0</button>
+      <button data-value=".">.</button>
+      <button id="equals">=</button>
+      <button data-value="+">+</button>
+    </div>
+    <div class="row">
+      <button id="clear" style="width:104px">C</button>
+    </div>
+  </div>
+
+  <script>
+    const display = document.getElementById('display');
+
+    function appendValue(value) {
+      display.value += value;
+    }
+
+    function clearDisplay() {
+      display.value = '';
+    }
+
+    function calculate() {
+      try {
+        display.value = eval(display.value) || '';
+      } catch (e) {
+        display.value = 'Error';
+      }
+    }
+
+    document.querySelectorAll('button[data-value]').forEach(button => {
+      button.addEventListener('click', () => appendValue(button.getAttribute('data-value')));
+    });
+
+    document.getElementById('clear').addEventListener('click', clearDisplay);
+    document.getElementById('equals').addEventListener('click', calculate);
+
+    document.addEventListener('keydown', (e) => {
+      if ('0123456789+-*/.'.includes(e.key)) {
+        appendValue(e.key);
+      } else if (e.key === 'Enter') {
+        calculate();
+      } else if (e.key === 'Escape') {
+        clearDisplay();
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a simple calculator UI with digits and basic operators
- add logic to compute expressions and clear display
- allow keyboard entry and document double-click launch

## Testing
- `echo "No tests to run"`


------
https://chatgpt.com/codex/tasks/task_e_68add2d7d2808333a970a95ef13ebf51